### PR TITLE
Improved algorithm for selecting fragments. Can handle up to 10 set effects no problem.

### DIFF
--- a/pages/calculator.js
+++ b/pages/calculator.js
@@ -288,8 +288,8 @@ export default class Calculator extends React.Component {
         const fragments = new Set()
         const chosenSetEffects = this.state.setEffects.filter(set => set.chosen)
 
-        if (chosenSetEffects.length > 5) {
-            this.setState({ buildPrompt: "Cannot have more than 5 sets.", possibleBuild: null })
+        if (chosenSetEffects.length > 8) {
+            this.setState({ buildPrompt: "Cannot have more than 8 sets.", possibleBuild: null })
             return
         }
 
@@ -310,12 +310,12 @@ export default class Calculator extends React.Component {
             return
         }
 
-        // For each selected set effect, have a number of remaining needed fragments
+        // For each selected set effect, maintain the number of needed fragments remaining
         let fragmentsRemaining = {}
         chosenSetEffects.forEach(set =>{fragmentsRemaining[set.name] = set.chosenCount})
         
         // Force inclusion of the fragments that must be included.
-        let filtered = [...mustIncludeFrags]
+        let bestFragments = [...mustIncludeFrags]
 
         // Update the counts of all the set effect fragments still needed
         mustIncludeFrags.forEach(frag => frag.setEffects.forEach(se => 
@@ -330,15 +330,14 @@ export default class Calculator extends React.Component {
 
         if (sumFragmentsRemaining == 0)
         {
-            this.setState({ possibleBuild: filtered})
+            this.setState({ possibleBuild: bestFragments})
             return
         } 
 
         // All of the fragments with two relevant effects (not including the mustInclude, because those are mandatory anyway)
         const doubleFrags = [...fragments].filter(frag => !frag.mustInclude && chosenSetEffects.find(s => s == frag.setEffects[0]) && chosenSetEffects.find(s => s == frag.setEffects[1]))
 
-        // Build all possible combinations of the the double fragments.
-        let bestFragments = [...filtered]
+        // Build all possible combinations of the the double fragments and test them with the mandatory fragments to find the best solution
         for (let i = 1; i < this.state.numSlots + 1 - mustIncludeFrags.size; i++)
         {
             // Get all the permutations of size i
@@ -501,7 +500,7 @@ export default class Calculator extends React.Component {
     render() {
         return (
             <div className="component-app">
-                <p>Choosing multiple sets may freeze for a few seconds. You cannot select more than 5 sets at a time.</p>
+                <p>You cannot select more than 8 sets at a time.</p>
                 <div className="pure-u-1 min-height-145">
                     <h1>Possible Build</h1>
                     <p>Click to exclude fragments. Re-enable them at the bottom of the page.</p>

--- a/pages/calculator.js
+++ b/pages/calculator.js
@@ -289,7 +289,7 @@ export default class Calculator extends React.Component {
         const chosenSetEffects = this.state.setEffects.filter(set => set.chosen)
 
         if (chosenSetEffects.length > 8) {
-            this.setState({ buildPrompt: "Cannot have more than 8 sets.", possibleBuild: null })
+            this.setState({ buildPrompt: "Cannot have more than 7 sets.", possibleBuild: null })
             return
         }
 
@@ -500,7 +500,6 @@ export default class Calculator extends React.Component {
     render() {
         return (
             <div className="component-app">
-                <p>You cannot select more than 8 sets at a time.</p>
                 <div className="pure-u-1 min-height-145">
                     <h1>Possible Build</h1>
                     <p>Click to exclude fragments. Re-enable them at the bottom of the page.</p>

--- a/pages/calculator.js
+++ b/pages/calculator.js
@@ -366,14 +366,14 @@ export default class Calculator extends React.Component {
                 if (fewestRemaining < sumFragmentsRemaining)
                 {
                     sumFragmentsRemaining = fewestRemaining
-                    bestFragments = [...mustIncludeFrags, ...perm]
+                    bestFragments = [...perm]
                 }
             }
         }
         
         // After all these have been exhausted, if there are still fragments remaining to be filled, check how many slots are left. 
         // If there aren't enough slots to satisfy the remaining set effects, it's impossible.
-        if (sumFragmentsRemaining > this.state.numSlots - bestFragments.length)
+        if (sumFragmentsRemaining > this.state.numSlots - bestFragments.length - mustIncludeFrags.size)
         {
             this.setState({ buildPrompt: "There are no possible combinations", possibleBuild: null })
             return
@@ -385,6 +385,8 @@ export default class Calculator extends React.Component {
                 if (se.name in fragmentsRemaining)
                     fragmentsRemaining[se.name] = Math.max(0, fragmentsRemaining[se.name] - 1)
         }))
+
+        bestFragments = [...bestFragments, ...mustIncludeFrags]
         
         // If we get to this point, from here we just fill in whatever slots are remaining with a fragment that has the necessary set effect.
         for (var se in fragmentsRemaining)

--- a/pages/calculator.js
+++ b/pages/calculator.js
@@ -334,26 +334,23 @@ export default class Calculator extends React.Component {
             return
         } 
 
-        // All of the fragments with two effects (not including the mustInclude, because those are mandatory anyway)
+        // All of the fragments with two relevant effects (not including the mustInclude, because those are mandatory anyway)
         const doubleFrags = [...fragments].filter(frag => !frag.mustInclude && chosenSetEffects.find(s => s == frag.setEffects[0]) && chosenSetEffects.find(s => s == frag.setEffects[1]))
 
-        // Build all possible combinations of the fragments that must be included and the double fragments.
-        // Build them or sort them in such a way that they're ordered fewest fragments to most fragments.
-
-        //let fewestRemaining = sumFragmentsRemaining
+        // Build all possible combinations of the the double fragments.
         let bestFragments = [...filtered]
-        for (let i = 1; i < this.state.numSlots - mustIncludeFrags.size; i++)
+        for (let i = 1; i < this.state.numSlots + 1 - mustIncludeFrags.size; i++)
         {
             // Get all the permutations of size i
             const perms = this.k_combinations(doubleFrags, i)
-
-            perms.forEach(perm =>
+            
+            for (var permID in perms)
             {
+                const perm = perms[permID]
                 const tempFragmentsRemaining = Object.assign({}, fragmentsRemaining)
-                perm.forEach(frag => frag.setEffects.forEach(se => 
-                    { 
-                        if (se.name in tempFragmentsRemaining)
-                            tempFragmentsRemaining[se.name] = Math.max(0, tempFragmentsRemaining[se.name] - 1)
+                perm.forEach(frag => frag.setEffects.forEach(se => { 
+                    if (se.name in tempFragmentsRemaining)
+                        tempFragmentsRemaining[se.name] = Math.max(0, tempFragmentsRemaining[se.name] - 1)
                 }))
                 
                 let fewestRemaining = 0
@@ -372,12 +369,11 @@ export default class Calculator extends React.Component {
                     sumFragmentsRemaining = fewestRemaining
                     bestFragments = [...mustIncludeFrags, ...perm]
                 }
-            })
+            }
         }
         
         // After all these have been exhausted, if there are still fragments remaining to be filled, check how many slots are left. 
         // If there aren't enough slots to satisfy the remaining set effects, it's impossible.
-
         if (sumFragmentsRemaining > this.state.numSlots - bestFragments.length)
         {
             this.setState({ buildPrompt: "There are no possible combinations", possibleBuild: null })
@@ -390,7 +386,6 @@ export default class Calculator extends React.Component {
                 if (se.name in fragmentsRemaining)
                     fragmentsRemaining[se.name] = Math.max(0, fragmentsRemaining[se.name] - 1)
         }))
-        
         
         // If we get to this point, from here we just fill in whatever slots are remaining with a fragment that has the necessary set effect.
         for (var se in fragmentsRemaining)
@@ -410,19 +405,6 @@ export default class Calculator extends React.Component {
         }
 
         this.setState({ possibleBuild: bestFragments })
-    }
-
-    worksForDesiredSetEffects(desiredSets, fragments) {
-        for (let set of desiredSets) {
-            let slots = 0
-            for (let frag of fragments) {
-                if (frag.owned && frag.setEffects.includes(set)) {
-                    slots++
-                }
-            }
-            if (slots < set.chosenCount) return false
-        }
-        return true
     }
 
     k_combinations(set, k) {


### PR DESCRIPTION
I figured the algorithm could be improved by focusing on fragments that have multiple relevant set effects. This greatly limits the number of permutations that need to be evaluated.

Basically how this new code works is the following:

Start with any that are selected to be included - these can be ignored from the permutations because they are mandatory.
Track how many fragments are still needed for each set effect.
Get a list of all the fragments that have two relevant set effects. 
Get all the possible permutations of these fragments. There are nowhere near as many compared to using all of the fragments that had just one relevant set effect.
Find the permutation that brings the number of remaining fragments needed the lowest.
If there are more fragments needed than slots remaining, stop.
Otherwise, just fill the remaining slots with fragments that have just one relevant set effect.